### PR TITLE
Handle dict vs string data type in endorse webhook 

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -195,7 +195,7 @@ services:
             --multitenant \
             --multitenant-admin \
             --jwt-secret '${ACAPY_AUTHOR_JWT_SECRET}' \
-            --wallet-type 'indy' \
+            --wallet-type 'askar' \
             --wallet-name '${ACAPY_AUTHOR_WALLET_DATABASE}' \
             --wallet-key '${ACAPY_AUTHOR_WALLET_ENCRYPTION_KEY}' \
             --wallet-storage-type '${ACAPY_AUTHOR_WALLET_STORAGE_TYPE}' \

--- a/endorser/api/endpoints/models/endorse.py
+++ b/endorser/api/endpoints/models/endorse.py
@@ -60,11 +60,15 @@ class EndorseTransactionList(BaseModel):
 def webhook_to_txn_object(payload: dict, endorser_did: str) -> EndorseTransaction:
     """Convert from a webhook payload to an endorser transaction."""
     logger.debug(f">>> from payload: {payload}")
-    transaction_request = (
-        json.loads(payload["messages_attach"][0]["data"]["json"])
-        if payload["messages_attach"][0]["data"]["json"]
-        else {}
-    )
+    if "json" in payload["messages_attach"][0]["data"] and payload["messages_attach"][0]["data"]["json"]:
+        # deal with str or dict types
+        payload_json = payload["messages_attach"][0]["data"]["json"]
+        if isinstance(payload_json, dict):
+            transaction_request = payload_json
+        else:
+            transaction_request = json.loads(payload_json)
+    else:
+        transaction_request = {}
     if 0 < len(payload["signature_response"]):
         transaction_response = (
             json.loads(


### PR DESCRIPTION
Related to aca-py issue https://github.com/hyperledger/aries-cloudagent-python/issues/1964
